### PR TITLE
feat(frontend): improve landing page with Google auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const signinForm = document.getElementById('signin-form');
   const signupMsg  = document.getElementById('signup-msg');
   const signinMsg  = document.getElementById('signin-msg');
+  const signupGoogle = document.getElementById('signup-google');
+  const signinGoogle = document.getElementById('signin-google');
   checkAndRedirectIfLogged();
   if (signupForm) {
     signupForm.addEventListener('submit', async (e) => {
@@ -24,6 +26,26 @@ document.addEventListener('DOMContentLoaded', () => {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) signinMsg.textContent = 'Erro no login: ' + error.message;
       else window.location.replace('app.html');
+    });
+  }
+  if (signupGoogle) {
+    signupGoogle.addEventListener('click', async () => {
+      signupMsg.textContent = '';
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.origin + '/app.html' }
+      });
+      if (error) signupMsg.textContent = 'Erro no cadastro: ' + error.message;
+    });
+  }
+  if (signinGoogle) {
+    signinGoogle.addEventListener('click', async () => {
+      signinMsg.textContent = '';
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.origin + '/app.html' }
+      });
+      if (error) signinMsg.textContent = 'Erro no login: ' + error.message;
     });
   }
   supabase.auth.onAuthStateChange(async (_event, session) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="utf-8" />
-  <title>Login • PMO Pro</title>
+  <title>PMO Pro - Login</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="./style.css" />
@@ -10,30 +10,40 @@
   <script src="./supabase-client.js" defer></script>
   <script src="./auth.js" defer></script>
 </head>
-<body class="min-h-screen bg-gray-50 text-gray-900">
-  <main class="max-w-lg mx-auto p-6">
-    <h1 class="text-2xl font-bold mb-4 text-center">Bem-vindo ao PMO Pro 🚀</h1>
-    <p class="text-sm text-gray-600 mb-8 text-center">Faça seu cadastro (Sign Up) e depois login (Sign In).</p>
-    <div class="grid gap-8">
-      <section class="card">
-        <h2 class="text-xl font-semibold mb-3">Sign Up</h2>
-        <form id="signup-form" class="grid gap-3">
-          <input id="signup-email" type="email" required placeholder="Seu e-mail" class="input" />
-          <input id="signup-password" type="password" required placeholder="Senha" class="input" />
-          <button class="btn w-full" type="submit">Criar conta</button>
-        </form>
-        <p id="signup-msg" class="msg"></p>
-      </section>
-      <section class="card">
-        <h2 class="text-xl font-semibold mb-3">Sign In</h2>
-        <form id="signin-form" class="grid gap-3">
-          <input id="signin-email" type="email" required placeholder="Seu e-mail" class="input" />
-          <input id="signin-password" type="password" required placeholder="Senha" class="input" />
-          <button class="btn w-full" type="submit">Entrar</button>
-        </form>
-        <p id="signin-msg" class="msg"></p>
-      </section>
-    </div>
+<body class="min-h-screen bg-gradient-to-br from-indigo-50 to-blue-50 flex items-center justify-center">
+  <main class="w-full max-w-md bg-white rounded-2xl shadow-md p-8">
+    <h1 class="text-3xl font-bold text-center mb-2">PMO Pro 🚀</h1>
+    <p class="text-center text-gray-600 mb-6">Gerencie seus projetos com facilidade.</p>
+
+    <section class="space-y-4 mb-8">
+      <h2 class="text-lg font-semibold">Sign Up</h2>
+      <form id="signup-form" class="space-y-3">
+        <input id="signup-email" type="email" required placeholder="Seu e-mail" class="w-full px-3 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <input id="signup-password" type="password" required placeholder="Senha" class="w-full px-3 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <button class="w-full px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors" type="submit">Criar conta</button>
+      </form>
+      <button id="signup-google" class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors">
+        <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" class="w-5 h-5" />
+        <span>Criar conta com Google</span>
+      </button>
+      <p id="signup-msg" class="text-sm text-center text-red-500"></p>
+    </section>
+
+    <div class="border-t mb-8"></div>
+
+    <section class="space-y-4">
+      <h2 class="text-lg font-semibold">Sign In</h2>
+      <form id="signin-form" class="space-y-3">
+        <input id="signin-email" type="email" required placeholder="Seu e-mail" class="w-full px-3 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <input id="signin-password" type="password" required placeholder="Senha" class="w-full px-3 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <button class="w-full px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors" type="submit">Entrar</button>
+      </form>
+      <button id="signin-google" class="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors">
+        <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" class="w-5 h-5" />
+        <span>Entrar com Google</span>
+      </button>
+      <p id="signin-msg" class="text-sm text-center text-red-500"></p>
+    </section>
   </main>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -25,7 +25,8 @@ const PIPEFY_OWNER_EMAIL_FIELD = process.env.PIPEFY_OWNER_EMAIL_FIELD || '';
 const app = express();
 app.use(cors());
 app.use(express.json());
-const PORT = process.env.PORT || 8080;
+// Use port provided by environment (Render) or default to 3000 for local dev
+const PORT = process.env.PORT || 3000;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
@@ -328,4 +329,8 @@ app.get('*', (req, res) => {
   });
 });
 
-app.listen(PORT, () => console.log('PMO Pro listening on http://localhost:' + PORT));
+// Bind explicitly to all IPv4 interfaces to avoid local "connection refused" issues
+// on systems where localhost resolves differently.
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`PMO Pro listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- polish login page layout with Tailwind and gradient background
- add Google OAuth buttons for sign up and sign in
- hook up new buttons to Supabase OAuth in auth.js
- default server to port 3000 so Google redirect works locally
- bind Express server to IPv4 to avoid localhost connection errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` (PMO Pro listening on http://localhost:3000)


------
https://chatgpt.com/codex/tasks/task_e_68be071d008483249f5c30da0f21ad0b