### PR TITLE
Add Kanban board with drag-and-drop

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/style.css" />
   <!-- Chart.js para gráficos -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <!-- SortableJS para o Kanban -->
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 </head>
 <body class="bg-slate-50 text-slate-900">
   <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
@@ -24,6 +26,7 @@
       <nav class="flex gap-2">
         <button data-tab="tab-dashboard" class="tab-btn active">Dashboard</button>
         <button data-tab="tab-projects" class="tab-btn">Projetos</button>
+        <button data-tab="tab-kanban" class="tab-btn">Kanban</button>
         <button data-tab="tab-professionals" class="tab-btn">Profissionais</button>
         <button data-tab="tab-allocations" class="tab-btn">Alocações</button>
       </nav>
@@ -95,6 +98,11 @@
       </div>
     </section>
 
+    <!-- KANBAN -->
+    <section id="tab-kanban" class="tab-panel hidden">
+      <div id="kanban-board" class="kanban-board"></div>
+    </section>
+
     <!-- PROFISSIONAIS -->
     <section id="tab-professionals" class="tab-panel hidden">
       <div class="card mb-4">
@@ -152,5 +160,6 @@
 
   <script src="/app.js" defer></script>
   <script src="/dashboard.js" defer></script>
+  <script src="/kanban.js" defer></script>
 </body>
 </html>

--- a/frontend/kanban.js
+++ b/frontend/kanban.js
@@ -1,0 +1,56 @@
+async function loadKanban() {
+  try {
+    const res = await fetch('/api/projects');
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'erro ao carregar projetos');
+
+    const board = document.getElementById('kanban-board');
+    if (!board) return;
+    board.innerHTML = '';
+
+    const groups = {};
+    (data || []).forEach(p => {
+      const s = p.status || 'Sem status';
+      (groups[s] = groups[s] || []).push(p);
+    });
+
+    Object.entries(groups).forEach(([status, items]) => {
+      const col = document.createElement('div');
+      col.className = 'kanban-column';
+      col.dataset.status = status;
+      col.innerHTML = `<div class="kanban-column-title">${status}</div><div class="kanban-column-cards"></div>`;
+      board.appendChild(col);
+
+      const cardsEl = col.querySelector('.kanban-column-cards');
+      items.forEach(p => {
+        const card = document.createElement('div');
+        card.className = 'kanban-card';
+        card.textContent = p.name || p.id;
+        card.dataset.id = p.id;
+        cardsEl.appendChild(card);
+      });
+
+      new Sortable(cardsEl, {
+        group: 'kanban',
+        animation: 150,
+        onEnd: evt => {
+          const card = evt.item;
+          const newStatus = evt.to.closest('.kanban-column').dataset.status;
+          fetch(`/api/projects/${card.dataset.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: newStatus })
+          }).catch(console.error);
+        }
+      });
+    });
+  } catch (e) {
+    console.error('loadKanban', e);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', loadKanban, { once: true });
+} else {
+  loadKanban();
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -20,3 +20,10 @@
 
 .tab-panel.hidden { display: none; }
 .tab-panel.block { display: block; }
+
+/* Kanban */
+.kanban-board { @apply flex items-start gap-4 overflow-x-auto; }
+.kanban-column { @apply bg-slate-100 rounded-xl p-3 min-w-[250px] flex-1; }
+.kanban-column-title { @apply font-semibold mb-3 text-sm; }
+.kanban-column-cards { @apply flex flex-col gap-3; }
+.kanban-card { @apply bg-white rounded-xl p-3 shadow cursor-move; }


### PR DESCRIPTION
## Summary
- add Kanban tab to app and load SortableJS
- implement frontend kanban.js to fetch projects and allow drag-and-drop between status columns
- style Kanban board columns and cards similar to Jira/Trello

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be10de0810832493e05dc871b675b7