### PR TITLE
refactor allocations module and add filters

### DIFF
--- a/frontend/allocations.js
+++ b/frontend/allocations.js
@@ -1,0 +1,66 @@
+// Funções de listagem e criação de alocações
+async function loadAllocations(filters = {}) {
+  try {
+    const params = new URLSearchParams();
+    if (filters.project_id) params.append('project_id', filters.project_id);
+    if (filters.professional_id) params.append('professional_id', filters.professional_id);
+    if (filters.start_date) params.append('start_date', filters.start_date);
+    if (filters.end_date) params.append('end_date', filters.end_date);
+    const qs = params.toString();
+    const r = await fetch('/api/allocations' + (qs ? `?${qs}` : ''));
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.error || 'erro');
+
+    const tbody = document.getElementById('allocations-tbody');
+    tbody.innerHTML = '';
+    (j || []).forEach(a => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="py-2 pr-4">${a.project_name ?? a.project_id}</td>
+        <td class="py-2 pr-4">${a.professional_name ?? a.professional_id}</td>
+        <td class="py-2 pr-4">${a.hours ?? 0}</td>
+        <td class="py-2">${(a.start_date || '')} — ${(a.end_date || '')}</td>
+      `;
+      tbody.appendChild(tr);
+    });
+  } catch (e) {
+    console.error('loadAllocations', e);
+  }
+}
+
+async function createAllocation() {
+  const project_id = document.getElementById('alloc-project').value;
+  const professional_id = document.getElementById('alloc-prof').value;
+  const hours = Number(document.getElementById('alloc-hours').value || 0);
+  const start_date = document.getElementById('alloc-start').value || null;
+  const end_date = document.getElementById('alloc-end').value || null;
+  if (!project_id || !professional_id) return alert('Selecione projeto e profissional');
+
+  try {
+    const r = await fetch('/api/allocations', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project_id, professional_id, hours, start_date, end_date })
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.error || 'erro ao criar alocação');
+    await loadAllocations();
+    alert('Alocação criada!');
+  } catch (e) {
+    alert('Erro: ' + e.message);
+  }
+}
+
+function applyAllocationFilters() {
+  const project_id = document.getElementById('filter-project')?.value || '';
+  const professional_id = document.getElementById('filter-prof')?.value || '';
+  const start_date = document.getElementById('filter-start')?.value || '';
+  const end_date = document.getElementById('filter-end')?.value || '';
+  loadAllocations({ project_id, professional_id, start_date, end_date });
+}
+
+document.getElementById('btnCreateAlloc')?.addEventListener('click', createAllocation);
+document.getElementById('btnFilterAlloc')?.addEventListener('click', applyAllocationFilters);
+
+loadAllocations();
+window.loadAllocations = loadAllocations;
+

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -124,20 +124,29 @@
 
     <!-- ALOCAÇÕES -->
     <section id="tab-allocations" class="tab-panel hidden">
-      <div class="card">
-        <div class="card-title">Alocações</div>
-        <div class="grid grid-cols-1 lg:grid-cols-5 gap-3 mb-3">
+      <div class="card mb-4">
+        <div class="card-title">Criar Alocação</div>
+        <div class="grid grid-cols-1 lg:grid-cols-5 gap-3">
           <select id="alloc-project" class="input"></select>
           <select id="alloc-prof" class="input"></select>
           <input id="alloc-hours" class="input" type="number" placeholder="Horas" />
           <input id="alloc-start" class="input" type="date" placeholder="Início" />
           <input id="alloc-end" class="input" type="date" placeholder="Fim" />
         </div>
-        <button id="btnCreateAlloc" class="btn-primary w-full">Criar Alocação</button>
+        <div class="mt-3">
+          <button id="btnCreateAlloc" class="btn-primary w-full">Criar Alocação</button>
+        </div>
       </div>
 
-      <div class="card mt-6">
-        <div class="card-title">Lista</div>
+      <div class="card">
+        <div class="card-title">Alocações</div>
+        <div class="grid grid-cols-1 lg:grid-cols-5 gap-3 mb-3">
+          <select id="filter-project" class="input"></select>
+          <select id="filter-prof" class="input"></select>
+          <input id="filter-start" class="input" type="date" />
+          <input id="filter-end" class="input" type="date" />
+          <button id="btnFilterAlloc" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Filtrar</button>
+        </div>
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead><tr class="text-left">
@@ -151,6 +160,7 @@
   </main>
 
   <script src="/app.js" defer></script>
+  <script src="/allocations.js" defer></script>
   <script src="/dashboard.js" defer></script>
 </body>
 </html>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,9 +8,11 @@ async function loadProjects() {
     // Se você quiser todos, troque por uma rota que liste /api/projects (você pode criar depois)
     // Aqui, para simplificar, uso os "top projects" só para preencher a tabela e selects.
     const tbody = document.getElementById('projects-tbody');
-    const sel = document.getElementById('alloc-project');
+    const selCreate = document.getElementById('alloc-project');
+    const selFilter = document.getElementById('filter-project');
     tbody.innerHTML = '';
-    sel.innerHTML = '';
+    selCreate.innerHTML = '';
+    if (selFilter) selFilter.innerHTML = '<option value="">Todos</option>';
 
     (j.items || []).forEach(p => {
       // tabela
@@ -24,11 +26,12 @@ async function loadProjects() {
       `;
       tbody.appendChild(tr);
 
-      // select
+      // selects
       const opt = document.createElement('option');
       opt.value = p.id;
       opt.textContent = p.name || p.id;
-      sel.appendChild(opt);
+      selCreate.appendChild(opt);
+      if (selFilter) selFilter.appendChild(opt.cloneNode(true));
     });
   } catch (e) {
     console.error('loadProjects', e);
@@ -42,9 +45,11 @@ async function loadProfessionals() {
     if (!r.ok) throw new Error(j.error || 'erro');
 
     const tbody = document.getElementById('professionals-tbody');
-    const sel = document.getElementById('alloc-prof');
+    const selCreate = document.getElementById('alloc-prof');
+    const selFilter = document.getElementById('filter-prof');
     tbody.innerHTML = '';
-    sel.innerHTML = '';
+    selCreate.innerHTML = '';
+    if (selFilter) selFilter.innerHTML = '<option value="">Todos</option>';
 
     (j || []).forEach(p => {
       const tr = document.createElement('tr');
@@ -54,7 +59,8 @@ async function loadProfessionals() {
       const opt = document.createElement('option');
       opt.value = p.id;
       opt.textContent = p.name;
-      sel.appendChild(opt);
+      selCreate.appendChild(opt);
+      if (selFilter) selFilter.appendChild(opt.cloneNode(true));
     });
   } catch (e) {
     console.error('loadProfessionals', e);
@@ -84,59 +90,12 @@ async function addProfessional() {
   }
 }
 
-async function loadAllocations() {
-  try {
-    const r = await fetch('/api/allocations');
-    const j = await r.json();
-    if (!r.ok) throw new Error(j.error || 'erro');
-
-    const tbody = document.getElementById('allocations-tbody');
-    tbody.innerHTML = '';
-    (j || []).forEach(a => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td class="py-2 pr-4">${a.project_name ?? a.project_id}</td>
-        <td class="py-2 pr-4">${a.professional_name ?? a.professional_id}</td>
-        <td class="py-2 pr-4">${a.hours ?? 0}</td>
-        <td class="py-2">${(a.start_date || '')} — ${(a.end_date || '')}</td>
-      `;
-      tbody.appendChild(tr);
-    });
-  } catch (e) {
-    console.error('loadAllocations', e);
-  }
-}
-
-async function createAllocation() {
-  const project_id = document.getElementById('alloc-project').value;
-  const professional_id = document.getElementById('alloc-prof').value;
-  const hours = Number(document.getElementById('alloc-hours').value || 0);
-  const start_date = document.getElementById('alloc-start').value || null;
-  const end_date = document.getElementById('alloc-end').value || null;
-  if (!project_id || !professional_id) return alert('Selecione projeto e profissional');
-
-  try {
-    const r = await fetch('/api/allocations', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ project_id, professional_id, hours, start_date, end_date })
-    });
-    const j = await r.json();
-    if (!r.ok) throw new Error(j.error || 'erro ao criar alocação');
-    await loadAllocations();
-    alert('Alocação criada!');
-  } catch (e) {
-    alert('Erro: ' + e.message);
-  }
-}
-
 // eventos
 document.getElementById('btnAddProf')?.addEventListener('click', addProfessional);
-document.getElementById('btnCreateAlloc')?.addEventListener('click', createAllocation);
 
 // carrega listas ao abrir
 loadProjects();
 loadProfessionals();
-loadAllocations();
 
 // expõe para o dashboard.js poder recarregar junto após sync
 window.loadProjects = loadProjects;

--- a/server.js
+++ b/server.js
@@ -226,14 +226,26 @@ app.post('/api/professionals', async (req, res) => {
   res.json(data);
 });
 
-app.get('/api/allocations', async (_req, res) => {
-  const { data, error } = await supabase
-    .from('allocations_view')
-    .select('*')
-    .order('created_at', { ascending: false })
-    .limit(500);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+app.get('/api/allocations', async (req, res) => {
+  try {
+    let query = supabase
+      .from('allocations_view')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(500);
+
+    const { project_id, professional_id, start_date, end_date } = req.query || {};
+    if (project_id) query = query.eq('project_id', project_id);
+    if (professional_id) query = query.eq('professional_id', professional_id);
+    if (start_date) query = query.gte('start_date', start_date);
+    if (end_date) query = query.lte('end_date', end_date);
+
+    const { data, error } = await query;
+    if (error) throw error;
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
 });
 
 app.post('/api/allocations', async (req, res) => {


### PR DESCRIPTION
## Summary
- extract allocation logic to new frontend/allocations.js with listing and create helpers
- redesign allocations tab and include project/professional/period filters
- support allocation filters on /api/allocations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` (start/stop)


------
https://chatgpt.com/codex/tasks/task_e_68be10e06df48324a5a4de363eb1d2b7