### PR TITLE
feat: fail fast on missing supabase env

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,14 @@ app.use(cors());
 app.use(express.json());
 // Use port provided by environment (Render) or default to 3000 for local dev
 const PORT = process.env.PORT || 3000;
+// Garante que a aplicação falhe de forma descritiva caso as variáveis do
+// Supabase não estejam configuradas. Sem esses valores, o `createClient`
+// lança um erro pouco claro ("supabaseUrl is required"), interrompendo o
+// deploy no Render.
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error('Configure SUPABASE_URL e SUPABASE_SERVICE_KEY no ambiente.');
+  process.exit(1);
+}
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 


### PR DESCRIPTION
## Summary
- exit early with descriptive message if SUPABASE_URL or SUPABASE_SERVICE_KEY is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `SUPABASE_URL=http://example.com SUPABASE_SERVICE_KEY=abc SUPABASE_ANON_KEY=def node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68be141335c883248941a9c986859e09