### PR TITLE
feat: fail fast on missing supabase env

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/server.js
+++ b/server.js
@@ -27,6 +27,14 @@ app.use(cors());
 app.use(express.json());
 // Use port provided by environment (Render) or default to 3000 for local dev
 const PORT = process.env.PORT || 3000;
+// Garante que a aplicação falhe de forma descritiva caso as variáveis do
+// Supabase não estejam configuradas. Sem esses valores, o `createClient`
+// lança um erro pouco claro ("supabaseUrl is required"), interrompendo o
+// deploy no Render.
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error('Configure SUPABASE_URL e SUPABASE_SERVICE_KEY no ambiente.');
+  process.exit(1);
+}
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+
+// Ensure the server exits with code 1 when required Supabase env vars are missing.
+test('server fails fast when Supabase env vars are missing', async () => {
+  await new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, ['server.js'], {
+      env: { ...process.env, SUPABASE_URL: '', SUPABASE_SERVICE_KEY: '' },
+    });
+    let stderr = '';
+    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.on('close', (code) => {
+      try {
+        assert.strictEqual(code, 1);
+        assert.match(stderr, /Configure SUPABASE_URL e SUPABASE_SERVICE_KEY/);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- exit early with descriptive message if SUPABASE_URL or SUPABASE_SERVICE_KEY is missing
- add npm test script and smoke test for missing Supabase env vars

## Testing
- `npm test`
- `SUPABASE_URL=http://example.com SUPABASE_SERVICE_KEY=abc SUPABASE_ANON_KEY=def node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68be141335c883248941a9c986859e09