### PR TITLE
feat: load Supabase client before app scripts

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -181,6 +181,9 @@
     </section>
   </main>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="/env.js" defer></script>
+  <script src="/supabase-client.js" defer></script>
   <script src="/app.js" defer></script>
   <script src="/allocations.js" defer></script>
   <script src="/dashboard.js" defer></script>


### PR DESCRIPTION
## Summary
- load Supabase library and client scripts before other front-end modules

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68be172d1e2c8324a39692f7403a2dae