### PR TITLE
Validate Supabase anon key on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Suba este repositório único no Render como **Web Service**. Frontend e backend
    - `SUPABASE_SERVICE_KEY` → **service_role**
    - `SUPABASE_ANON_KEY` → **anon public**
 
+> Sem `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` e `SUPABASE_ANON_KEY`, o servidor não inicia.
+
 ### Pipefy
 
 - `PIPEFY_TOKEN`: token de API disponível em <https://app.pipefy.com/profile/developers>.

--- a/server.js
+++ b/server.js
@@ -36,6 +36,11 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
   process.exit(1);
 }
 
+if (!SUPABASE_ANON_KEY) {
+  console.error('Configure SUPABASE_ANON_KEY no ambiente.');
+  process.exit(1);
+}
+
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 // Expor variáveis públicas para o frontend

--- a/server.test.js
+++ b/server.test.js
@@ -21,3 +21,23 @@ test('server fails fast when Supabase env vars are missing', async () => {
     });
   });
 });
+
+// Ensure the server exits with code 1 when Supabase anon key is missing.
+test('server fails fast when Supabase anon key is missing', async () => {
+  await new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, ['server.js'], {
+      env: { ...process.env, SUPABASE_URL: 'x', SUPABASE_SERVICE_KEY: 'x', SUPABASE_ANON_KEY: '' },
+    });
+    let stderr = '';
+    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.on('close', (code) => {
+      try {
+        assert.strictEqual(code, 1);
+        assert.match(stderr, /Configure SUPABASE_ANON_KEY/);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fail fast if SUPABASE_ANON_KEY is missing
- test early exit when Supabase anon key is absent
- document anon key requirement in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1c8742388324b8cfae8e49cb5c30