### PR TITLE
Add Supabase schema and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ Suba este repositório único no Render como **Web Service**. Frontend e backend
 2. Cadastre `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_ANON_KEY`, `PIPEFY_TOKEN`, `PIPEFY_PIPE_IDS`, `PIPEFY_STATUS_FIELD` e `PIPEFY_OWNER_EMAIL_FIELD` com os mesmos valores do `.env` local.
 3. Salve e reinicie o serviço para aplicar.
 
+## Banco de dados (Supabase)
+
+O arquivo [`supabase-schema.sql`](./supabase-schema.sql) contém as tabelas e views usadas pela aplicação:
+`projects`, `professionals`, `allocations` e `allocations_view`.
+
+### Executar pelo dashboard
+1. Acesse o projeto no [app.supabase.com](https://app.supabase.com/).
+2. Abra **SQL Editor → New query**.
+3. Copie o conteúdo de `supabase-schema.sql` e clique em **Run**.
+
+### Executar via CLI
+1. Instale o [Supabase CLI](https://supabase.com/docs/guides/cli) e faça login (`supabase login`).
+2. Vincule seu projeto: `supabase link --project-ref <REF_DO_PROJETO>`.
+3. Rode o script: `supabase db query supabase-schema.sql`.
+
 ## Deploy
 1. GitHub → New repo → Upload files (tudo desta pasta).
 2. Render → New → Web Service → Build from repo

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,0 +1,49 @@
+-- SQL para criar tabelas e views utilizadas pela aplicação PMO Pro
+
+-- Tabela de projetos sincronizados do Pipefy
+create table if not exists projects (
+  id bigserial primary key,
+  external_id text unique not null,
+  name text not null,
+  status text,
+  owner_email text,
+  meta jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Tabela de profissionais
+create table if not exists professionals (
+  id bigserial primary key,
+  name text not null,
+  email text unique,
+  role text,
+  created_at timestamptz default now()
+);
+
+-- Tabela de alocações de profissionais em projetos
+create table if not exists allocations (
+  id bigserial primary key,
+  project_id bigint not null references projects(id) on delete cascade,
+  professional_id bigint not null references professionals(id) on delete cascade,
+  hours numeric,
+  start_date date,
+  end_date date,
+  created_at timestamptz default now()
+);
+
+-- View de alocações com nomes de projeto e profissional
+create or replace view allocations_view as
+select
+  a.id,
+  a.project_id,
+  p.name as project_name,
+  a.professional_id,
+  pr.name as professional_name,
+  a.hours,
+  a.start_date,
+  a.end_date,
+  a.created_at
+from allocations a
+  left join projects p on p.id = a.project_id
+  left join professionals pr on pr.id = a.professional_id;


### PR DESCRIPTION
## Summary
- add SQL script defining projects, professionals, allocations and allocations_view tables
- document how to run the schema via Supabase dashboard or CLI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1c9187bc8324b5eb302ea80a0aed