### PR TITLE
feat: add settings page

### DIFF
--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>PMO Pro • Configurações</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
+    <h1 class="text-2xl font-bold">Configurações</h1>
+    <a href="/app.html" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Voltar</a>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-4 pb-24">
+    <nav class="flex gap-2 mb-6">
+      <button data-tab="tab-team" class="tab-btn active">Equipe e Custos</button>
+      <button data-tab="tab-integrations" class="tab-btn">Integrações</button>
+    </nav>
+
+    <section id="tab-team" class="tab-panel block">
+      <div id="team-list" class="space-y-2"></div>
+    </section>
+
+    <section id="tab-integrations" class="tab-panel hidden">
+      <div class="space-y-3 max-w-md">
+        <input id="pipefyApiKey" class="input" placeholder="Pipefy API Key" />
+        <input id="pipefyPipeId" class="input" placeholder="Pipe ID" />
+        <input id="serviceCodes" class="input" placeholder="Siglas de serviço (separadas por vírgula)" />
+        <button id="btnSaveSync" class="btn-primary">Salvar e Sincronizar</button>
+      </div>
+    </section>
+  </main>
+
+  <script src="/settings.js" defer></script>
+</body>
+</html>

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -1,0 +1,89 @@
+// Controle de abas internas
+function initTabs() {
+  const buttons = document.querySelectorAll('.tab-btn');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.tab;
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.querySelectorAll('.tab-panel').forEach(p => {
+        p.classList.add('hidden');
+        p.classList.remove('block');
+      });
+      const el = document.getElementById(target);
+      el.classList.remove('hidden');
+      el.classList.add('block');
+    });
+  });
+}
+
+// Listagem de profissionais com inputs editáveis e botão Remover
+async function loadTeam() {
+  try {
+    const r = await fetch('/api/professionals');
+    const list = await r.json();
+    const container = document.getElementById('team-list');
+    container.innerHTML = '';
+    (list || []).forEach(p => {
+      const row = document.createElement('div');
+      row.className = 'flex gap-2 items-center';
+      row.innerHTML = `
+        <input class="input flex-1" value="${p.name || ''}" />
+        <input class="input flex-1" value="${p.email || ''}" />
+        <input class="input w-32" value="${p.role || ''}" />
+        <button class="px-3 py-2 rounded-xl bg-red-100 text-red-700 text-sm remove-prof" data-id="${p.id}">Remover</button>
+      `;
+      container.appendChild(row);
+      row.querySelector('.remove-prof').addEventListener('click', async () => {
+        row.remove();
+        try {
+          await fetch('/api/professionals/' + p.id, { method: 'DELETE' });
+        } catch (e) {
+          console.error('Erro ao remover profissional', e);
+        }
+      });
+    });
+  } catch (e) {
+    console.error('loadTeam', e);
+  }
+}
+
+// Carrega configurações de integração do localStorage
+function loadIntegration() {
+  document.getElementById('pipefyApiKey').value = localStorage.getItem('pipefyApiKey') || '';
+  document.getElementById('pipefyPipeId').value = localStorage.getItem('pipefyPipeId') || '';
+  document.getElementById('serviceCodes').value = localStorage.getItem('serviceCodes') || '';
+}
+
+function saveIntegration() {
+  localStorage.setItem('pipefyApiKey', document.getElementById('pipefyApiKey').value.trim());
+  localStorage.setItem('pipefyPipeId', document.getElementById('pipefyPipeId').value.trim());
+  localStorage.setItem('serviceCodes', document.getElementById('serviceCodes').value.trim());
+}
+
+// Botão Salvar e Sincronizar
+async function handlePipefySync() {
+  const btn = document.getElementById('btnSaveSync');
+  try {
+    btn.disabled = true;
+    const r = await fetch('/api/sync/pipefy', { method: 'POST', cache: 'no-store' });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.error || 'erro');
+    alert(`Sincronizado: ${j.upserts ?? 0} projeto(s)`);
+  } catch (e) {
+    alert('Erro: ' + e.message);
+  } finally {
+    btn.disabled = false;
+  }
+}
+window.handlePipefySync = handlePipefySync;
+
+document.getElementById('btnSaveSync').addEventListener('click', async () => {
+  saveIntegration();
+  await handlePipefySync();
+});
+
+// Inicialização
+initTabs();
+loadTeam();
+loadIntegration();


### PR DESCRIPTION
## Summary
- add settings page with internal tab control
- manage team members with editable inputs and remove button
- store Pipefy integration settings in localStorage and expose Save & Sync action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c4b357cc8324aed7ca6c72e84102