### PR TITLE
feat: add global notifications and login simulation

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -15,6 +15,10 @@
   <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold">PMO Pro</h1>
     <div class="flex items-center gap-3">
+      <div id="user-info" class="flex items-center gap-2 mr-2">
+        <img id="user-avatar" class="w-8 h-8 rounded-full" src="" alt="avatar" />
+        <span id="user-name" class="text-sm"></span>
+      </div>
       <button id="btnSync" class="px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm">🔄 Sincronizar Pipefy → Projetos</button>
       <button id="btnLogout" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Sair</button>
     </div>
@@ -181,9 +185,21 @@
     </section>
   </main>
 
+  <div id="notification-container"></div>
+  <div id="confirmation-modal" class="hidden">
+    <div class="modal-box">
+      <p id="confirmation-message"></p>
+      <div class="modal-actions">
+        <button id="confirm-yes" class="btn-primary">Confirmar</button>
+        <button id="confirm-no" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Cancelar</button>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="/env.js" defer></script>
   <script src="/supabase-client.js" defer></script>
+  <script src="/ui.js" defer></script>
   <script src="/app.js" defer></script>
   <script src="/allocations.js" defer></script>
   <script src="/dashboard.js" defer></script>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -92,8 +92,27 @@ async function addProfessional() {
 
 // eventos
 document.getElementById('btnAddProf')?.addEventListener('click', addProfessional);
+function handleLogin() {
+  let user = {};
+  try {
+    user = JSON.parse(localStorage.getItem('demoUser') || '{}');
+  } catch {}
+  if (!user.name) {
+    user = {
+      name: 'Usuário Demo',
+      avatar: `https://i.pravatar.cc/40?u=demo`
+    };
+    localStorage.setItem('demoUser', JSON.stringify(user));
+  }
+  const avatarEl = document.getElementById('user-avatar');
+  const nameEl = document.getElementById('user-name');
+  if (avatarEl) avatarEl.src = user.avatar;
+  if (nameEl) nameEl.textContent = user.name;
+  showNotification(`Bem-vindo, ${user.name}!`, 'success');
+}
 
 // carrega listas ao abrir
+handleLogin();
 loadProjects();
 loadProfessionals();
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -6,6 +6,7 @@
   <title>PMO Pro • Dashboard</title>
   <!-- Tailwind CDN (ok para prototipagem) -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./style.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
@@ -111,7 +112,19 @@
     </section>
   </main>
 
+  <div id="notification-container"></div>
+  <div id="confirmation-modal" class="hidden">
+    <div class="modal-box">
+      <p id="confirmation-message"></p>
+      <div class="modal-actions">
+        <button id="confirm-yes" class="btn btn-primary">Confirmar</button>
+        <button id="confirm-no" class="btn btn-soft">Cancelar</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Seu JS do dashboard -->
+  <script src="./ui.js" defer></script>
   <script src="./dashboard.js" defer></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="/env.js" defer></script>
   <script src="./supabase-client.js" defer></script>
+  <script src="./ui.js" defer></script>
   <script src="./auth.js" defer></script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-indigo-50 to-blue-50 flex flex-col">
@@ -55,6 +56,16 @@
     </section>
   </main>
   <footer class="text-center py-4 text-xs text-gray-500">© 2024 PMO Pro</footer>
+  <div id="notification-container"></div>
+  <div id="confirmation-modal" class="hidden">
+    <div class="modal-box">
+      <p id="confirmation-message"></p>
+      <div class="modal-actions">
+        <button id="confirm-yes" class="btn-primary">Confirmar</button>
+        <button id="confirm-no" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Cancelar</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -27,3 +27,14 @@
 .kanban-column-title { @apply font-semibold mb-3 text-sm; }
 .kanban-column-cards { @apply flex flex-col gap-3; }
 .kanban-card { @apply bg-white rounded-xl p-3 shadow cursor-move; }
+/* Notifications */
+#notification-container { @apply fixed top-4 right-4 z-50 flex flex-col gap-2; }
+.notification { @apply px-4 py-2 rounded-xl shadow text-white text-sm; }
+.notification-info { @apply bg-slate-800; }
+.notification-success { @apply bg-green-600; }
+.notification-error { @apply bg-red-600; }
+
+/* Confirmation modal */
+#confirmation-modal { @apply fixed inset-0 bg-black/50 flex items-center justify-center hidden z-50; }
+#confirmation-modal .modal-box { @apply bg-white rounded-xl p-6 max-w-sm w-full text-center; }
+#confirmation-modal .modal-actions { @apply mt-4 flex justify-center gap-3; }

--- a/frontend/ui.js
+++ b/frontend/ui.js
@@ -1,0 +1,44 @@
+function showNotification(message, type = 'info') {
+  const container = document.getElementById('notification-container');
+  if (!container) return;
+  const el = document.createElement('div');
+  el.className = `notification notification-${type}`;
+  el.textContent = message;
+  container.appendChild(el);
+  setTimeout(() => el.remove(), 3000);
+}
+
+function confirmAction(message, onConfirm, onCancel) {
+  const modal = document.getElementById('confirmation-modal');
+  const msgEl = document.getElementById('confirmation-message');
+  const yesBtn = document.getElementById('confirm-yes');
+  const noBtn = document.getElementById('confirm-no');
+  if (!modal || !msgEl || !yesBtn || !noBtn) {
+    if (confirm(message)) {
+      onConfirm && onConfirm();
+    } else {
+      onCancel && onCancel();
+    }
+    return;
+  }
+  msgEl.textContent = message;
+  modal.classList.remove('hidden');
+  function cleanup() {
+    modal.classList.add('hidden');
+    yesBtn.removeEventListener('click', yesHandler);
+    noBtn.removeEventListener('click', noHandler);
+  }
+  async function yesHandler() {
+    cleanup();
+    await onConfirm?.();
+  }
+  function noHandler() {
+    cleanup();
+    onCancel?.();
+  }
+  yesBtn.addEventListener('click', yesHandler);
+  noBtn.addEventListener('click', noHandler);
+}
+
+window.showNotification = showNotification;
+window.confirmAction = confirmAction;


### PR DESCRIPTION
## Summary
- add global notification container and reusable showNotification helper
- implement confirmation modal with callback support for critical actions
- simulate login with avatar display and demo notification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c4b4fa9483248f3c84694df73046