### PR TITLE
feat: add planner view rendering

### DIFF
--- a/frontend/planner.js
+++ b/frontend/planner.js
@@ -28,7 +28,7 @@ function renderPlannerView() {
   table.appendChild(thead);
 
   const tbody = document.createElement('tbody');
-  const allocations = state?.db?.allocations || [];
+  const allocations = globalThis.state?.db?.allocations || [];
   const professionals = {};
 
   allocations.forEach(a => {


### PR DESCRIPTION
## Summary
- add planner.js with renderPlannerView to build monthly allocation table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c4a32ee88324accdefe8f859f6e4