### PR TITLE
Guard settings init with DOMContentLoaded

### DIFF
--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -78,12 +78,16 @@ async function handlePipefySync() {
 }
 window.handlePipefySync = handlePipefySync;
 
-document.getElementById('btnSaveSync').addEventListener('click', async () => {
-  saveIntegration();
-  await handlePipefySync();
-});
+document.addEventListener('DOMContentLoaded', () => {
+  initTabs();
+  loadTeam();
+  loadIntegration();
 
-// Inicialização
-initTabs();
-loadTeam();
-loadIntegration();
+  const btnSaveSync = document.getElementById('btnSaveSync');
+  if (btnSaveSync) {
+    btnSaveSync.addEventListener('click', async () => {
+      saveIntegration();
+      await handlePipefySync();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Run settings initialization on DOMContentLoaded
- Safely attach `#btnSaveSync` handler only when present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c505eaa84883249e54b3c2f7804e59