### PR TITLE
Use float for allocation hours

### DIFF
--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -26,7 +26,7 @@ create table if not exists allocations (
   id bigserial primary key,
   project_id bigint not null references projects(id) on delete cascade,
   professional_id bigint not null references professionals(id) on delete cascade,
-  hours numeric,
+  hours double precision,
   start_date date,
   end_date date,
   created_at timestamptz default now()


### PR DESCRIPTION
## Summary
- store allocation hours as double precision to avoid string aggregation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b61dca8c832492d14b0444ee3028