### PR TITLE
fix: sanitize team member fields in settings page

### DIFF
--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -27,14 +27,30 @@ async function loadTeam() {
     (list || []).forEach(p => {
       const row = document.createElement('div');
       row.className = 'flex gap-2 items-center';
-      row.innerHTML = `
-        <input class="input flex-1" value="${p.name || ''}" />
-        <input class="input flex-1" value="${p.email || ''}" />
-        <input class="input w-32" value="${p.role || ''}" />
-        <button class="px-3 py-2 rounded-xl bg-red-100 text-red-700 text-sm remove-prof" data-id="${p.id}">Remover</button>
-      `;
+      const nameInput = document.createElement('input');
+      nameInput.className = 'input flex-1';
+      nameInput.value = p.name || '';
+      row.appendChild(nameInput);
+
+      const emailInput = document.createElement('input');
+      emailInput.className = 'input flex-1';
+      emailInput.value = p.email || '';
+      row.appendChild(emailInput);
+
+      const roleInput = document.createElement('input');
+      roleInput.className = 'input w-32';
+      roleInput.value = p.role || '';
+      row.appendChild(roleInput);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'px-3 py-2 rounded-xl bg-red-100 text-red-700 text-sm remove-prof';
+      removeBtn.dataset.id = p.id;
+      removeBtn.textContent = 'Remover';
+      row.appendChild(removeBtn);
+
       container.appendChild(row);
-      row.querySelector('.remove-prof').addEventListener('click', async () => {
+
+      removeBtn.addEventListener('click', async () => {
         row.remove();
         try {
           await fetch('/api/professionals/' + p.id, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
- create DOM elements instead of interpolating team data into HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b6fe8fd48324b4d9c72929e13273