### PR TITLE
fix: wire profitability module into dashboard

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -78,6 +78,31 @@
         </div>
       </section>
 
+      <!-- Profitability -->
+      <section id="dashboard-profitability" class="mb-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div class="card">
+            <div class="card-title">Lucro por Projeto</div>
+            <canvas id="profitabilityChart" height="120"></canvas>
+          </div>
+          <div class="card">
+            <div class="card-title">Tabela de Lucro</div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead><tr class="text-left">
+                  <th class="py-2 pr-4">Projeto</th>
+                  <th class="py-2 pr-4 text-right">Receita</th>
+                  <th class="py-2 pr-4 text-right">Custo</th>
+                  <th class="py-2 pr-4 text-right">Lucro</th>
+                  <th class="py-2 text-right">Margem</th>
+                </tr></thead>
+                <tbody id="profitabilityTable"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- Tabela -->
       <section id="dashboard-top-projects">
         <div class="card">
@@ -206,6 +231,7 @@
   <script src="/app.js" defer></script>
   <script src="/allocations.js" defer></script>
   <script src="/dashboard.js" defer></script>
+  <script src="/profitability.js" defer></script>
   <script src="/kanban.js" defer></script>
   <script src="/portfolio.js" defer></script>
 </body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -90,6 +90,33 @@
       </div>
     </section>
 
+    <!-- Profitability -->
+    <section class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div class="card p-4">
+        <div class="flex items-center justify-between mb-2">
+          <h2 class="font-semibold text-gray-900">Lucro por projeto</h2>
+        </div>
+        <canvas id="profitabilityChart" height="160"></canvas>
+      </div>
+      <div class="card p-4 overflow-x-auto">
+        <div class="flex items-center justify-between mb-2">
+          <h2 class="font-semibold text-gray-900">Tabela de lucro</h2>
+        </div>
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-gray-500 border-b">
+            <tr>
+              <th class="py-2 pr-4">Projeto</th>
+              <th class="py-2 pr-4 text-right">Receita</th>
+              <th class="py-2 pr-4 text-right">Custo</th>
+              <th class="py-2 pr-4 text-right">Lucro</th>
+              <th class="py-2 text-right">Margem</th>
+            </tr>
+          </thead>
+          <tbody id="profitabilityTable" class="divide-y"></tbody>
+        </table>
+      </div>
+    </section>
+
     <!-- Lista Top Projetos -->
     <section class="card p-4">
       <div class="flex items-center justify-between mb-3">
@@ -126,5 +153,6 @@
   <!-- Seu JS do dashboard -->
   <script src="./ui.js" defer></script>
   <script src="./dashboard.js" defer></script>
+  <script src="./profitability.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add profitability chart and table containers
- load profitability.js on dashboard pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b7e500148324907c4e6fe4f1fefa