### PR TITLE
fix stray code after top-projects endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -225,9 +225,6 @@ app.get('/api/metrics/top-projects', async (req, res) => {
   }
 });
 
-main
-});
-
 // ===== CRUD já existentes =====
 app.get('/api/professionals', async (_req, res) => {
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- remove leftover `main` and extra closing line after top-projects metrics endpoint

## Testing
- `npm test`
- `node server.js` *(fails fast due to missing SUPABASE env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c37513e083249e04eeaa09c17040