### PR TITLE
Add shared navigation bar and hash-based tab routing

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -236,6 +236,7 @@
     </div>
   </div>
 
+  <script src="/navbar.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="/env.js" defer></script>
   <script src="/supabase-client.js" defer></script>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -123,3 +123,22 @@ async function addProfessional() {
 
 // expõe para o dashboard.js poder recarregar junto após sync
 window.loadProjects = loadProjects;
+
+// Navegação por hash para permitir links diretos para abas
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const view = btn.dataset.tab;
+      switchView(view);
+      location.hash = view;
+    });
+  });
+
+  window.addEventListener('hashchange', () => {
+    const view = location.hash.slice(1);
+    if (view) switchView(view);
+  });
+
+  const initial = location.hash.slice(1) || 'tab-dashboard';
+  switchView(initial);
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -21,19 +21,12 @@
   </style>
 </head>
 <body class="bg-gray-50 min-h-screen">
-  <!-- Topbar -->
-  <header class="sticky top-0 z-20 bg-white/80 backdrop-blur border-b border-gray-200">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3">
-      <a href="/app.html" class="text-sm text-gray-500 hover:text-gray-700">← Voltar</a>
-      <h1 class="text-xl sm:text-2xl font-bold text-gray-900">PMO Pro — Dashboard</h1>
-      <div class="ml-auto flex items-center gap-2">
-        <button id="btnSync" class="btn btn-soft">Sincronizar Pipefy → Projetos</button>
-        <button id="btnLogout" class="btn btn-soft">Sair</button>
-      </div>
-    </div>
-  </header>
-
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+    <div class="flex items-center gap-3 mb-6">
+      <h1 class="text-xl sm:text-2xl font-bold text-gray-900 flex-1">Dashboard</h1>
+      <button id="btnSync" class="btn btn-soft">Sincronizar Pipefy → Projetos</button>
+      <button id="btnLogout" class="btn btn-soft">Sair</button>
+    </div>
     <!-- View Switcher -->
     <section class="card p-4">
       <div class="flex flex-col md:flex-row md:items-center gap-3">
@@ -151,6 +144,7 @@
   </div>
 
   <!-- Seu JS do dashboard -->
+  <script src="./navbar.js" defer></script>
   <script src="./ui.js" defer></script>
   <script src="./dashboard.js" defer></script>
   <script src="./profitability.js" defer></script>

--- a/frontend/management.html
+++ b/frontend/management.html
@@ -8,12 +8,8 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900">
-  <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold">Gestão</h1>
-    <a href="/app.html" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Voltar</a>
-  </header>
-
   <main class="max-w-6xl mx-auto px-4 pb-24">
+    <h1 class="text-2xl font-bold mb-6">Gestão</h1>
     <nav class="flex gap-2 mb-6">
       <button data-tab="tab-batch" class="mgmt-tab-btn tab-btn active">Alocação em Lote</button>
       <button data-tab="tab-cleanup" class="mgmt-tab-btn tab-btn">Limpeza</button>
@@ -41,6 +37,7 @@
     </section>
   </main>
 
+  <script src="/navbar.js" defer></script>
   <script src="/management.js" defer></script>
 </body>
 </html>

--- a/frontend/navbar.js
+++ b/frontend/navbar.js
@@ -1,0 +1,42 @@
+// Simple responsive navigation bar injected on each page
+// Provides links to main sections and highlights the active one
+
+document.addEventListener('DOMContentLoaded', () => {
+  const nav = document.createElement('nav');
+  nav.className = 'bg-indigo-600 text-white';
+  nav.innerHTML = `
+    <div class="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
+      <a href="/app.html" class="font-semibold text-lg">PMO Pro</a>
+      <button id="nav-toggle" class="md:hidden">☰</button>
+      <div id="nav-links" class="hidden md:flex md:items-center md:gap-4">
+        <a href="/app.html#tab-dashboard" class="nav-link hover:underline">Dashboard</a>
+        <a href="/app.html#tab-projects" class="nav-link hover:underline">Projetos</a>
+        <a href="/app.html#tab-kanban" class="nav-link hover:underline">Kanban</a>
+        <a href="/dashboard.html" class="nav-link hover:underline">Relatórios</a>
+        <a href="/settings.html" class="nav-link hover:underline">Configurações</a>
+      </div>
+    </div>
+    <div id="nav-mobile" class="md:hidden hidden px-4 pb-4 flex flex-col gap-2 bg-indigo-600">
+      <a href="/app.html#tab-dashboard" class="nav-link">Dashboard</a>
+      <a href="/app.html#tab-projects" class="nav-link">Projetos</a>
+      <a href="/app.html#tab-kanban" class="nav-link">Kanban</a>
+      <a href="/dashboard.html" class="nav-link">Relatórios</a>
+      <a href="/settings.html" class="nav-link">Configurações</a>
+    </div>
+  `;
+  document.body.prepend(nav);
+
+  const toggle = nav.querySelector('#nav-toggle');
+  toggle.addEventListener('click', () => {
+    nav.querySelector('#nav-links').classList.toggle('hidden');
+    nav.querySelector('#nav-mobile').classList.toggle('hidden');
+  });
+
+  const current = window.location.pathname + (window.location.hash || '#tab-dashboard');
+  nav.querySelectorAll('.nav-link').forEach(link => {
+    const href = link.getAttribute('href');
+    if (href === current) {
+      link.classList.add('underline', 'font-semibold');
+    }
+  });
+});

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -8,12 +8,8 @@
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body class="bg-slate-50 text-slate-900">
-  <header class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold">Configurações</h1>
-    <a href="/app.html" class="px-4 py-2 rounded-xl bg-slate-200 hover:bg-slate-300 text-sm">Voltar</a>
-  </header>
-
   <main class="max-w-6xl mx-auto px-4 pb-24">
+    <h1 class="text-2xl font-bold mb-6">Configurações</h1>
     <nav class="flex gap-2 mb-6">
       <button data-tab="tab-team" class="tab-btn active">Equipe e Custos</button>
       <button data-tab="tab-integrations" class="tab-btn">Integrações</button>
@@ -33,6 +29,7 @@
     </section>
   </main>
 
+  <script src="/navbar.js" defer></script>
   <script src="/settings.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add reusable responsive navigation bar component with links to core sections
- Integrate navbar across dashboard, settings, management and main app pages
- Enable hash-based tab navigation so links open correct tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c773b31483249f6d900f83e7833a