### PR TITLE
Store Pipefy settings in Supabase and regenerate summary

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -241,6 +241,7 @@
   <script src="/env.js" defer></script>
   <script src="/supabase-client.js" defer></script>
   <script src="/ui.js" defer></script>
+  <script src="/sync.js" defer></script>
   <script src="/app.js" defer></script>
   <script src="/allocations.js" defer></script>
   <script src="/dashboard.js" defer></script>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -30,6 +30,7 @@
   </main>
 
   <script src="/navbar.js" defer></script>
+  <script src="/sync.js" defer></script>
   <script src="/settings.js" defer></script>
 </body>
 </html>

--- a/frontend/sync.js
+++ b/frontend/sync.js
@@ -1,0 +1,58 @@
+(() => {
+  'use strict';
+
+  async function callGeminiAPI(prompt) {
+    let res;
+    try {
+      res = await fetch('/api/gemini', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+    } catch (e) {
+      throw new Error('Erro de rede ao acessar Gemini API');
+    }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.error) {
+      throw new Error(data.error || data.message || 'Falha na Gemini API');
+    }
+    return data.text || data.response || '';
+  }
+
+  async function regenerateSummary() {
+    const el = document.getElementById('dashboard-summary');
+    if (!el) return;
+    try {
+      const r = await fetch('/api/metrics/overview');
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || 'erro');
+      const prompt = `Faça um breve resumo executivo do portfólio de projetos com base nas métricas: total ${j.total_projects}, novos 30d ${j.projects_last_30d}, owners ${j.owners}, horas ${j.total_hours}.`;
+      const txt = await callGeminiAPI(prompt);
+      el.textContent = txt;
+    } catch (e) {
+      console.error('regenerateSummary', e);
+    }
+  }
+
+  async function handlePipefySync() {
+    const btn = document.getElementById('btnSync') || document.getElementById('btnSaveSync');
+    try {
+      if (btn) btn.disabled = true;
+      const r = await fetch('/api/sync/pipefy', { method: 'POST', cache: 'no-store' });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || 'erro');
+      await window.loadProjects?.();
+      await regenerateSummary();
+      alert(`Sincronizado: ${j.upserts ?? 0} projeto(s)`);
+    } catch (e) {
+      alert('Erro: ' + e.message);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  window.handlePipefySync = handlePipefySync;
+  window.regenerateSummary = regenerateSummary;
+
+  document.getElementById('btnSync')?.addEventListener('click', handlePipefySync);
+})();

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -32,6 +32,13 @@ create table if not exists allocations (
   created_at timestamptz default now()
 );
 
+-- Tabela de configurações simples (chave/valor)
+create table if not exists settings (
+  key text primary key,
+  value text,
+  updated_at timestamptz default now()
+);
+
 -- View de alocações com nomes de projeto e profissional
 create or replace view allocations_view as
 select


### PR DESCRIPTION
## Summary
- persist Pipefy token and pipe IDs in new `settings` table
- expose `/api/settings` and load/save integration settings from frontend
- trigger Pipefy sync via API and regenerate dashboard summary with Gemini

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca1a89188324838c8069b56e5ae8