### PR TITLE
Add Gemini API proxy and frontend helper

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,6 +9,21 @@ const state = {
   }
 };
 
+// Chamada helper para a API Gemini via backend
+async function callGemini(prompt, params = {}) {
+  const res = await fetch('/api/gemini', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt, ...params })
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error) {
+    throw new Error(data.error || 'Erro ao chamar Gemini');
+  }
+  return data;
+}
+window.callGemini = callGemini;
+
 // Alterna visualizações principais (tabs)
 function switchView(viewId) {
   document.querySelectorAll('.tab-panel').forEach(sec => {


### PR DESCRIPTION
## Summary
- Add `/api/gemini` POST route in server to call Google Gemini API using `GEMINI_API_KEY` and optional schema support
- Expose `callGemini` helper in frontend for centralized AI requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca1ce454832485c67977a63e4802